### PR TITLE
JavadocAppenderToolの実装と機能拡張

### DIFF
--- a/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
+++ b/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
@@ -273,7 +273,8 @@ public class JavadocAppenderTool {
 
         }
 
-        return fileContentBuilder.toString();
+        String result = fileContentBuilder.toString();
+        return result;
 
     }
 

--- a/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
+++ b/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
@@ -12,6 +12,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import kmg.core.domain.service.KmgPfaMeasService;
+import kmg.core.domain.service.impl.KmgPfaMeasServiceImpl;
 import kmg.core.infrastructure.types.KmgDelimiterTypes;
 
 /**
@@ -57,14 +59,21 @@ public class JavadocAppenderTool {
         /* 対象のJavaファイルを取得 */
         final List<Path> javaFileList;
 
+        int fileCount = 0;
+
         try (final Stream<Path> streamPath = Files.walk(JavadocAppenderTool.INPUT_PATH)) {
 
             javaFileList = streamPath.filter(Files::isRegularFile).filter(path -> path.toString().endsWith(".java"))
                 .collect(Collectors.toList());
 
+            fileCount += javaFileList.size();
+
         }
 
         /* 対象のJavaファイルをすべて読み込む */
+
+        int lineCount = 0;
+
         for (final Path javaFile : javaFileList) {
 
             final StringBuilder fileContentBuilder = new StringBuilder();
@@ -76,6 +85,8 @@ public class JavadocAppenderTool {
                 String  line        = null;
 
                 while ((line = br.readLine()) != null) {
+
+                    lineCount++;
 
                     final String trimmedLine = line.trim();
 
@@ -180,6 +191,9 @@ public class JavadocAppenderTool {
 
         }
 
+        System.out.println(String.format("fileCount: %d", fileCount));
+        System.out.println(String.format("lineCount: %d", lineCount));
+
         return result;
 
     }
@@ -242,6 +256,9 @@ public class JavadocAppenderTool {
 
         final Class<JavadocAppenderTool> clasz = JavadocAppenderTool.class;
 
+        final KmgPfaMeasService measService = new KmgPfaMeasServiceImpl(clasz.toString());
+        measService.start();
+
         try {
 
             final JavadocAppenderTool main = new JavadocAppenderTool();
@@ -259,7 +276,7 @@ public class JavadocAppenderTool {
         } finally {
 
             System.out.println(String.format("%s：成功", clasz.toString()));
-            System.out.println(String.format("%s：終了", clasz.toString()));
+            measService.end();
 
         }
 

--- a/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
+++ b/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
@@ -91,6 +91,14 @@ public class JavadocAppenderTool {
                     /* Javadocの終了判定 */
                     if (isInJavadoc && trimmedLine.endsWith("*/")) {
 
+                        /* tagMapの内容を挿入 */
+                        for (final Map.Entry<String, String> entry : tagMap.entrySet()) {
+
+                            javadocBuilder.append(" * ").append(entry.getKey()).append(" ").append(entry.getValue())
+                                .append(KmgDelimiterTypes.LINE_SEPARATOR.get());
+
+                        }
+
                         isInJavadoc = false;
                         javadocBuilder.append(line).append(KmgDelimiterTypes.LINE_SEPARATOR.get());
                         System.out.println("Found Javadoc:");

--- a/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
+++ b/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
@@ -254,14 +254,13 @@ public class JavadocAppenderTool {
      */
     public static void main(final String[] args) {
 
-        final Class<JavadocAppenderTool> clasz = JavadocAppenderTool.class;
-
-        final KmgPfaMeasService measService = new KmgPfaMeasServiceImpl(clasz.toString());
+        final Class<JavadocAppenderTool> clasz       = JavadocAppenderTool.class;
+        final KmgPfaMeasService          measService = new KmgPfaMeasServiceImpl(clasz.toString());
         measService.start();
 
-        try {
+        final JavadocAppenderTool main = new JavadocAppenderTool();
 
-            final JavadocAppenderTool main = new JavadocAppenderTool();
+        try {
 
             if (!main.run()) {
 

--- a/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
+++ b/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
@@ -48,7 +48,7 @@ public class JavadocAppenderTool {
      */
     public Boolean run() throws FileNotFoundException, IOException {
 
-        final boolean result = true;
+        boolean result = true;
 
         /* タグマップの取得 */
         final Map<String, String> tagMap = this.getTagMap();
@@ -139,18 +139,17 @@ public class JavadocAppenderTool {
             }
 
             /* 修正した内容をファイルに書き込む */
-            // try {
-            //
-            // Files.writeString(javaFile, fileContentBuilder.toString());
-            //
-            // } catch (final IOException e) {
-            //
-            // System.err.println("Error writing to file: " + javaFile);
-            // e.printStackTrace();
-            // result = false;
-            //
-            // }
-            System.out.println(fileContentBuilder.toString());
+            try {
+
+                Files.writeString(javaFile, fileContentBuilder.toString());
+
+            } catch (final IOException e) {
+
+                System.err.println("Error writing to file: " + javaFile);
+                e.printStackTrace();
+                result = false;
+
+            }
 
         }
 

--- a/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
+++ b/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
@@ -143,8 +143,9 @@ public class JavadocAppenderTool {
 
                 final String trimmedLine = line.trim();
 
-                /* Javadocの開始判定 */
                 if (trimmedLine.startsWith("/**")) {
+
+                    /* Javadocの開始 */
 
                     isInJavadoc = true;
                     javadocBuilder.setLength(0);
@@ -180,8 +181,9 @@ public class JavadocAppenderTool {
 
                 }
 
-                /* Javadocの終了判定 */
                 if (isInJavadoc && trimmedLine.endsWith("*/")) {
+
+                    /* Javadocの終了 */
 
                     isInJavadoc = false;
 
@@ -273,7 +275,7 @@ public class JavadocAppenderTool {
 
         }
 
-        String result = fileContentBuilder.toString();
+        final String result = fileContentBuilder.toString();
         return result;
 
     }

--- a/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
+++ b/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
@@ -1,9 +1,65 @@
 package kmg.tool.presentation;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Collectors;
+
+import kmg.core.infrastructure.types.KmgDelimiterTypes;
+
 /**
  * Javadoc追加ツール
  */
 public class JavadocAppenderTool {
+
+    /** 基準パス */
+    private static final Path BASE_PATH = Paths.get(String.format("src/main/resources/tool/io"));
+
+    /** テンプレートファイルパス */
+    // TODO KenichiroArai 2025/02/23 自動設定
+    private static final Path TEMPLATE_PATH
+        = Paths.get(JavadocAppenderTool.BASE_PATH.toString(), "template/JavadocAppenderTool.txt");
+
+    /**
+     * 実行する<br>
+     *
+     * @author KenichiroArai
+     *
+     * @sine 0.1.0
+     *
+     * @version 0.1.0
+     *
+     * @return TRUE：成功、FLASE：失敗
+     *
+     * @throws FileNotFoundException
+     *                               ファイルが存在しない例外
+     * @throws IOException
+     *                               入出力例外
+     */
+    @SuppressWarnings("static-method")
+    public Boolean run() throws FileNotFoundException, IOException {
+
+        final Boolean result = Boolean.FALSE;
+
+        /* テンプレートの取得 */
+        String template = null;
+
+        try {
+
+            template = Files.readAllLines(JavadocAppenderTool.TEMPLATE_PATH).stream()
+                .collect(Collectors.joining(KmgDelimiterTypes.LINE_SEPARATOR.get()));
+
+        } catch (final IOException e) {
+
+            throw e;
+
+        }
+
+        return result;
+
+    }
 
     /**
      * メインメソッド
@@ -12,7 +68,29 @@ public class JavadocAppenderTool {
      *             引数
      */
     public static void main(final String[] args) {
-        // TODO 自動生成されたメソッド・スタブ
+
+        final Class<JavadocAppenderTool> clasz = JavadocAppenderTool.class;
+
+        try {
+
+            final JavadocAppenderTool main = new JavadocAppenderTool();
+
+            if (main.run()) {
+
+                System.out.println(String.format("%s：失敗", clasz.toString()));
+
+            }
+
+        } catch (final Exception e) {
+
+            e.printStackTrace();
+
+        } finally {
+
+            System.out.println(String.format("%s：成功", clasz.toString()));
+            System.out.println(String.format("%s：終了", clasz.toString()));
+
+        }
 
     }
 

--- a/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
+++ b/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
@@ -22,8 +22,8 @@ public class JavadocAppenderTool {
 
     /** テンプレートファイルパス */
     // TODO KenichiroArai 2025/02/23 自動設定
-    private static final Path TEMPLATE_PATH
-        = Paths.get(JavadocAppenderTool.BASE_PATH.toString(), "template/JavadocAppenderTool.txt");
+    private static final Path TEMPLATE_PATH = Paths.get(JavadocAppenderTool.BASE_PATH.toString(),
+            "template/JavadocAppenderTool.txt");
 
     /** 入力パス */
     private static final Path INPUT_PATH = Paths.get("D:\\eclipse_git_wk\\DictOpeProj\\kmg-core");
@@ -54,7 +54,15 @@ public class JavadocAppenderTool {
 
         /* 対象のJavaファイルを取得 */
         final List<Path> javaFiles = Files.walk(JavadocAppenderTool.INPUT_PATH).filter(Files::isRegularFile)
-            .filter(path -> path.toString().endsWith(".java")).collect(Collectors.toList());
+                .filter(path -> path.toString().endsWith(".java")).collect(Collectors.toList());
+
+        /* 対象のJavaファイルをすべて読み込む */
+        for (final Path javaFile : javaFiles) {
+
+            final String javaFileContent = Files.readString(javaFile);
+            System.out.println(javaFileContent);
+
+        }
 
         return result;
 
@@ -88,8 +96,8 @@ public class JavadocAppenderTool {
             }
 
             final String[] parts = KmgDelimiterTypes.SERIES_HALF_SPACE.split(trimmedLine, 2);
-            final String   tag   = parts[0].trim();
-            final String   value = parts[1].trim();
+            final String tag = parts[0].trim();
+            final String value = parts[1].trim();
             result.put(tag, value);
 
         }

--- a/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
+++ b/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
@@ -48,7 +48,7 @@ public class JavadocAppenderTool {
      */
     public Boolean run() throws FileNotFoundException, IOException {
 
-        final boolean result = false;
+        final boolean result = true;
 
         /* タグマップの取得 */
         final Map<String, String> tagMap = this.getTagMap();
@@ -67,7 +67,7 @@ public class JavadocAppenderTool {
         /* 対象のJavaファイルをすべて読み込む */
         for (final Path javaFile : javaFileList) {
 
-            final StringBuilder javadocBuilder = new StringBuilder();
+            final StringBuilder fileContentBuilder = new StringBuilder();
 
             try (BufferedReader br = Files.newBufferedReader(javaFile)) {
 
@@ -83,7 +83,7 @@ public class JavadocAppenderTool {
                     if (trimmedLine.startsWith("/**")) {
 
                         isInJavadoc = true;
-                        javadocBuilder.append(line).append(KmgDelimiterTypes.LINE_SEPARATOR.get());
+                        fileContentBuilder.append(line).append(KmgDelimiterTypes.LINE_SEPARATOR.get());
                         continue;
 
                     }
@@ -94,58 +94,63 @@ public class JavadocAppenderTool {
                         /* tagMapの内容を挿入 */
                         for (final Map.Entry<String, String> entry : tagMap.entrySet()) {
 
-                            javadocBuilder.append(" * ").append(entry.getKey()).append(" ").append(entry.getValue())
+                            fileContentBuilder.append(" * ").append(entry.getKey()).append(" ").append(entry.getValue())
                                 .append(KmgDelimiterTypes.LINE_SEPARATOR.get());
 
                         }
 
                         isInJavadoc = false;
-                        javadocBuilder.append(line).append(KmgDelimiterTypes.LINE_SEPARATOR.get());
-                        System.out.println("Found Javadoc:");
-                        System.out.println(javadocBuilder.toString());
-                        javadocBuilder.setLength(0);
+                        fileContentBuilder.append(line).append(KmgDelimiterTypes.LINE_SEPARATOR.get());
                         continue;
 
                     }
 
                     /* Javadoc内の行の処理 */
+                    if (isInJavadoc) {
+                        // Javadoc内の場合
 
-                    if (!isInJavadoc) {
-                        // Javadoc内ではない。
+                        // tagMapのキーに該当する行は追加しない
+                        boolean shouldSkip = false;
 
-                        continue;
+                        for (final String tag : tagMap.keySet()) {
 
-                    }
+                            if (!trimmedLine.contains(tag)) {
 
-                    // tagMapのキーに該当する行は追加しない
-                    boolean shouldSkip = false;
+                                continue;
 
-                    for (final String tag : tagMap.keySet()) {
+                            }
 
-                        if (!trimmedLine.contains(tag)) {
+                            shouldSkip = true;
+                            break;
+
+                        }
+
+                        if (shouldSkip) {
 
                             continue;
 
                         }
 
-                        shouldSkip = true;
-                        break;
-
                     }
-
-                    if (shouldSkip) {
-
-                        continue;
-
-                    }
-
-                    javadocBuilder.append(line).append(KmgDelimiterTypes.LINE_SEPARATOR.get());
+                    fileContentBuilder.append(line).append(KmgDelimiterTypes.LINE_SEPARATOR.get());
 
                 }
 
             }
 
-            System.out.println(javadocBuilder.toString());
+            /* 修正した内容をファイルに書き込む */
+            // try {
+            //
+            // Files.writeString(javaFile, fileContentBuilder.toString());
+            //
+            // } catch (final IOException e) {
+            //
+            // System.err.println("Error writing to file: " + javaFile);
+            // e.printStackTrace();
+            // result = false;
+            //
+            // }
+            System.out.println(fileContentBuilder.toString());
 
         }
 

--- a/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
+++ b/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
@@ -49,41 +49,8 @@ public class JavadocAppenderTool {
 
         final Boolean result = Boolean.FALSE;
 
-        /* テンプレートの取得 */
-
-        // タグマップ。キー:タグ、値:テキスト
-        final Map<String, String> tagMap = new HashMap<>();
-
-        // テンプレートの読み込み
-        List<String> lines = null;
-
-        try {
-
-            lines = Files.readAllLines(JavadocAppenderTool.TEMPLATE_PATH);
-
-        } catch (final IOException e) {
-
-            throw e;
-
-        }
-
-        // タグマップの設定
-        for (final String line : lines) {
-
-            final String trimmedLine = line.trim();
-
-            if (!trimmedLine.startsWith(KmgDelimiterTypes.HALF_AT_SIGN.get())) {
-
-                continue;
-
-            }
-
-            final String[] parts = KmgDelimiterTypes.SERIES_HALF_SPACE.split(trimmedLine, 2);
-            final String   tag   = parts[0].trim();
-            final String   value = parts[1].trim();
-            tagMap.put(tag, value);
-
-        }
+        /* タグマップの取得 */
+        final Map<String, String> tagMap = this.getTagMap();
         System.out.println(tagMap.toString());
 
         /* 対象のJavaファイルを取得 */
@@ -91,7 +58,35 @@ public class JavadocAppenderTool {
             .filter(path -> path.toString().endsWith(".java")).collect(Collectors.toList());
 
         return result;
+    }
 
+    /**
+     * タグマップを取得する<br>
+     * 
+     * @return タグマップ
+     * @throws IOException 入出力例外
+     */
+    private Map<String, String> getTagMap() throws IOException {
+        final Map<String, String> result = new HashMap<>();
+
+        /* テンプレートの読み込み */
+        final List<String> lines = Files.readAllLines(JavadocAppenderTool.TEMPLATE_PATH);
+
+        /* タグマップの作成 */
+        for (final String line : lines) {
+            final String trimmedLine = line.trim();
+
+            if (!trimmedLine.startsWith(KmgDelimiterTypes.HALF_AT_SIGN.get())) {
+                continue;
+            }
+
+            final String[] parts = KmgDelimiterTypes.SERIES_HALF_SPACE.split(trimmedLine, 2);
+            final String tag = parts[0].trim();
+            final String value = parts[1].trim();
+            result.put(tag, value);
+        }
+
+        return result;
     }
 
     /**

--- a/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
+++ b/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
@@ -1,0 +1,19 @@
+package kmg.tool.presentation;
+
+/**
+ * Javadoc追加ツール
+ */
+public class JavadocAppenderTool {
+
+    /**
+     * メインメソッド
+     *
+     * @param args
+     *             引数
+     */
+    public static void main(final String[] args) {
+        // TODO 自動生成されたメソッド・スタブ
+
+    }
+
+}

--- a/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
+++ b/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
@@ -263,19 +263,21 @@ public class JavadocAppenderTool {
 
             final JavadocAppenderTool main = new JavadocAppenderTool();
 
-            if (main.run()) {
+            if (!main.run()) {
 
                 System.out.println(String.format("%s：失敗", clasz.toString()));
 
             }
+            System.out.println(String.format("%s：成功", clasz.toString()));
 
         } catch (final Exception e) {
+
+            System.out.println(String.format("%s：例外発生", clasz.toString()));
 
             e.printStackTrace();
 
         } finally {
 
-            System.out.println(String.format("%s：成功", clasz.toString()));
             measService.end();
 
         }

--- a/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
+++ b/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
@@ -67,14 +67,14 @@ public class JavadocAppenderTool {
         /* 対象のJavaファイルをすべて読み込む */
         for (final Path javaFile : javaFileList) {
 
+            final StringBuilder javadocBuilder = new StringBuilder();
+
             try (BufferedReader br = Files.newBufferedReader(javaFile)) {
 
-                /* 初期値の設定 */
-                String              line           = null;
-                boolean             isInJavadoc    = false;
-                final StringBuilder javadocBuilder = new StringBuilder();
-
                 /* 行ごとの読み込み */
+                boolean isInJavadoc = false;
+                String  line        = null;
+
                 while ((line = br.readLine()) != null) {
 
                     final String trimmedLine = line.trim();
@@ -101,15 +101,43 @@ public class JavadocAppenderTool {
                     }
 
                     /* Javadoc内の行の処理 */
-                    if (isInJavadoc) {
 
-                        javadocBuilder.append(line).append(KmgDelimiterTypes.LINE_SEPARATOR.get());
+                    if (!isInJavadoc) {
+                        // Javadoc内ではない。
+
+                        continue;
 
                     }
+
+                    // tagMapのキーに該当する行は追加しない
+                    boolean shouldSkip = false;
+
+                    for (final String tag : tagMap.keySet()) {
+
+                        if (!trimmedLine.contains(tag)) {
+
+                            continue;
+
+                        }
+
+                        shouldSkip = true;
+                        break;
+
+                    }
+
+                    if (shouldSkip) {
+
+                        continue;
+
+                    }
+
+                    javadocBuilder.append(line).append(KmgDelimiterTypes.LINE_SEPARATOR.get());
 
                 }
 
             }
+
+            System.out.println(javadocBuilder.toString());
 
         }
 

--- a/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
+++ b/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
@@ -44,7 +44,6 @@ public class JavadocAppenderTool {
      * @throws IOException
      *                               入出力例外
      */
-    @SuppressWarnings("static-method")
     public Boolean run() throws FileNotFoundException, IOException {
 
         final Boolean result = Boolean.FALSE;
@@ -58,15 +57,20 @@ public class JavadocAppenderTool {
             .filter(path -> path.toString().endsWith(".java")).collect(Collectors.toList());
 
         return result;
+
     }
 
     /**
      * タグマップを取得する<br>
-     * 
+     *
      * @return タグマップ
-     * @throws IOException 入出力例外
+     *
+     * @throws IOException
+     *                     入出力例外
      */
+    @SuppressWarnings("static-method")
     private Map<String, String> getTagMap() throws IOException {
+
         final Map<String, String> result = new HashMap<>();
 
         /* テンプレートの読み込み */
@@ -74,19 +78,24 @@ public class JavadocAppenderTool {
 
         /* タグマップの作成 */
         for (final String line : lines) {
+
             final String trimmedLine = line.trim();
 
             if (!trimmedLine.startsWith(KmgDelimiterTypes.HALF_AT_SIGN.get())) {
+
                 continue;
+
             }
 
             final String[] parts = KmgDelimiterTypes.SERIES_HALF_SPACE.split(trimmedLine, 2);
-            final String tag = parts[0].trim();
-            final String value = parts[1].trim();
+            final String   tag   = parts[0].trim();
+            final String   value = parts[1].trim();
             result.put(tag, value);
+
         }
 
         return result;
+
     }
 
     /**

--- a/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
+++ b/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
@@ -5,6 +5,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import kmg.core.infrastructure.types.KmgDelimiterTypes;
@@ -21,6 +24,9 @@ public class JavadocAppenderTool {
     // TODO KenichiroArai 2025/02/23 自動設定
     private static final Path TEMPLATE_PATH
         = Paths.get(JavadocAppenderTool.BASE_PATH.toString(), "template/JavadocAppenderTool.txt");
+
+    /** 入力パス */
+    private static final Path INPUT_PATH = Paths.get("D:\\eclipse_git_wk\\DictOpeProj\\kmg-core");
 
     /**
      * 実行する<br>
@@ -44,18 +50,45 @@ public class JavadocAppenderTool {
         final Boolean result = Boolean.FALSE;
 
         /* テンプレートの取得 */
-        String template = null;
+
+        // タグマップ。キー:タグ、値:テキスト
+        final Map<String, String> tagMap = new HashMap<>();
+
+        // テンプレートの読み込み
+        List<String> lines = null;
 
         try {
 
-            template = Files.readAllLines(JavadocAppenderTool.TEMPLATE_PATH).stream()
-                .collect(Collectors.joining(KmgDelimiterTypes.LINE_SEPARATOR.get()));
+            lines = Files.readAllLines(JavadocAppenderTool.TEMPLATE_PATH);
 
         } catch (final IOException e) {
 
             throw e;
 
         }
+
+        // タグマップの設定
+        for (final String line : lines) {
+
+            final String trimmedLine = line.trim();
+
+            if (!trimmedLine.startsWith(KmgDelimiterTypes.HALF_AT_SIGN.get())) {
+
+                continue;
+
+            }
+
+            final String[] parts = KmgDelimiterTypes.SERIES_HALF_SPACE.split(trimmedLine, 2);
+            final String   tag   = parts[0].trim();
+            final String   value = parts[1].trim();
+            tagMap.put(tag, value);
+
+        }
+        System.out.println(tagMap.toString());
+
+        /* 対象のJavaファイルを取得 */
+        final List<Path> javaFiles = Files.walk(JavadocAppenderTool.INPUT_PATH).filter(Files::isRegularFile)
+            .filter(path -> path.toString().endsWith(".java")).collect(Collectors.toList());
 
         return result;
 

--- a/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
+++ b/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
@@ -83,13 +83,35 @@ public class JavadocAppenderTool {
                     if (trimmedLine.startsWith("/**")) {
 
                         isInJavadoc = true;
-                        fileContentBuilder.append(line).append(KmgDelimiterTypes.LINE_SEPARATOR.get());
-                        continue;
+
+                        if (!trimmedLine.endsWith("*/")) {
+
+                            // Javadocの開始行の末尾に*/がない（1行）場合
+
+                            fileContentBuilder.append(line).append(KmgDelimiterTypes.LINE_SEPARATOR.get());
+                            continue;
+
+                        }
 
                     }
 
                     /* Javadocの終了判定 */
                     if (isInJavadoc && trimmedLine.endsWith("*/")) {
+
+                        isInJavadoc = false;
+
+                        if (trimmedLine.startsWith("/**")) {
+
+                            // Javadocの開始行と終了行が同じ場合
+
+                            fileContentBuilder.append("/**").append(KmgDelimiterTypes.LINE_SEPARATOR.get());
+
+                            // lineからコメントを取得する
+                            final String comment = trimmedLine.substring(3, trimmedLine.length() - 2);
+
+                            fileContentBuilder.append(comment).append(KmgDelimiterTypes.LINE_SEPARATOR.get());
+
+                        }
 
                         /* tagMapの内容を挿入 */
                         for (final Map.Entry<String, String> entry : tagMap.entrySet()) {
@@ -99,39 +121,44 @@ public class JavadocAppenderTool {
 
                         }
 
-                        isInJavadoc = false;
-                        fileContentBuilder.append(line).append(KmgDelimiterTypes.LINE_SEPARATOR.get());
+                        fileContentBuilder.append("*/").append(KmgDelimiterTypes.LINE_SEPARATOR.get());
                         continue;
 
                     }
 
                     /* Javadoc内の行の処理 */
-                    if (isInJavadoc) {
-                        // Javadoc内の場合
+                    if (!isInJavadoc) {
 
-                        // tagMapのキーに該当する行は追加しない
-                        boolean shouldSkip = false;
+                        fileContentBuilder.append(line).append(KmgDelimiterTypes.LINE_SEPARATOR.get());
 
-                        for (final String tag : tagMap.keySet()) {
+                        continue;
 
-                            if (!trimmedLine.contains(tag)) {
+                    }
 
-                                continue;
+                    // Javadoc内の場合
 
-                            }
+                    // tagMapのキーに該当する行は追加しない
+                    boolean shouldSkip = false;
 
-                            shouldSkip = true;
-                            break;
+                    for (final String tag : tagMap.keySet()) {
 
-                        }
-
-                        if (shouldSkip) {
+                        if (!trimmedLine.contains(tag)) {
 
                             continue;
 
                         }
 
+                        shouldSkip = true;
+                        break;
+
                     }
+
+                    if (shouldSkip) {
+
+                        continue;
+
+                    }
+
                     fileContentBuilder.append(line).append(KmgDelimiterTypes.LINE_SEPARATOR.get());
 
                 }

--- a/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
+++ b/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
@@ -1,5 +1,6 @@
 package kmg.tool.presentation;
 
+import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -9,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import kmg.core.infrastructure.types.KmgDelimiterTypes;
 
@@ -46,21 +48,32 @@ public class JavadocAppenderTool {
      */
     public Boolean run() throws FileNotFoundException, IOException {
 
-        final Boolean result = Boolean.FALSE;
+        final boolean result = false;
 
         /* タグマップの取得 */
         final Map<String, String> tagMap = this.getTagMap();
         System.out.println(tagMap.toString());
 
         /* 対象のJavaファイルを取得 */
-        final List<Path> javaFiles = Files.walk(JavadocAppenderTool.INPUT_PATH).filter(Files::isRegularFile)
-            .filter(path -> path.toString().endsWith(".java")).collect(Collectors.toList());
+        final List<Path> javaFileList;
+
+        try (final Stream<Path> streamPath = Files.walk(JavadocAppenderTool.INPUT_PATH)) {
+
+            javaFileList = streamPath.filter(Files::isRegularFile).filter(path -> path.toString().endsWith(".java"))
+                .collect(Collectors.toList());
+
+        }
 
         /* 対象のJavaファイルをすべて読み込む */
-        for (final Path javaFile : javaFiles) {
+        for (final Path javaFile : javaFileList) {
 
-            final String javaFileContent = Files.readString(javaFile);
-            System.out.println(javaFileContent);
+            try (BufferedReader br = Files.newBufferedReader(javaFile)) {
+
+                final String javaFileContent
+                    = br.lines().collect(Collectors.joining(KmgDelimiterTypes.LINE_SEPARATOR.get()));
+                System.out.println(javaFileContent);
+
+            }
 
         }
 

--- a/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
+++ b/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
@@ -69,9 +69,45 @@ public class JavadocAppenderTool {
 
             try (BufferedReader br = Files.newBufferedReader(javaFile)) {
 
-                final String javaFileContent
-                    = br.lines().collect(Collectors.joining(KmgDelimiterTypes.LINE_SEPARATOR.get()));
-                System.out.println(javaFileContent);
+                /* 初期値の設定 */
+                String              line           = null;
+                boolean             isInJavadoc    = false;
+                final StringBuilder javadocBuilder = new StringBuilder();
+
+                /* 行ごとの読み込み */
+                while ((line = br.readLine()) != null) {
+
+                    final String trimmedLine = line.trim();
+
+                    /* Javadocの開始判定 */
+                    if (trimmedLine.startsWith("/**")) {
+
+                        isInJavadoc = true;
+                        javadocBuilder.append(line).append(KmgDelimiterTypes.LINE_SEPARATOR.get());
+                        continue;
+
+                    }
+
+                    /* Javadocの終了判定 */
+                    if (isInJavadoc && trimmedLine.endsWith("*/")) {
+
+                        isInJavadoc = false;
+                        javadocBuilder.append(line).append(KmgDelimiterTypes.LINE_SEPARATOR.get());
+                        System.out.println("Found Javadoc:");
+                        System.out.println(javadocBuilder.toString());
+                        javadocBuilder.setLength(0);
+                        continue;
+
+                    }
+
+                    /* Javadoc内の行の処理 */
+                    if (isInJavadoc) {
+
+                        javadocBuilder.append(line).append(KmgDelimiterTypes.LINE_SEPARATOR.get());
+
+                    }
+
+                }
 
             }
 

--- a/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
+++ b/src/main/java/kmg/tool/presentation/JavadocAppenderTool.java
@@ -22,8 +22,8 @@ public class JavadocAppenderTool {
 
     /** テンプレートファイルパス */
     // TODO KenichiroArai 2025/02/23 自動設定
-    private static final Path TEMPLATE_PATH = Paths.get(JavadocAppenderTool.BASE_PATH.toString(),
-            "template/JavadocAppenderTool.txt");
+    private static final Path TEMPLATE_PATH
+        = Paths.get(JavadocAppenderTool.BASE_PATH.toString(), "template/JavadocAppenderTool.txt");
 
     /** 入力パス */
     private static final Path INPUT_PATH = Paths.get("D:\\eclipse_git_wk\\DictOpeProj\\kmg-core");
@@ -54,7 +54,7 @@ public class JavadocAppenderTool {
 
         /* 対象のJavaファイルを取得 */
         final List<Path> javaFiles = Files.walk(JavadocAppenderTool.INPUT_PATH).filter(Files::isRegularFile)
-                .filter(path -> path.toString().endsWith(".java")).collect(Collectors.toList());
+            .filter(path -> path.toString().endsWith(".java")).collect(Collectors.toList());
 
         /* 対象のJavaファイルをすべて読み込む */
         for (final Path javaFile : javaFiles) {
@@ -82,7 +82,17 @@ public class JavadocAppenderTool {
         final Map<String, String> result = new HashMap<>();
 
         /* テンプレートの読み込み */
-        final List<String> lines = Files.readAllLines(JavadocAppenderTool.TEMPLATE_PATH);
+        List<String> lines = null;
+
+        try {
+
+            lines = Files.readAllLines(JavadocAppenderTool.TEMPLATE_PATH);
+
+        } catch (final IOException e) {
+
+            throw e;
+
+        }
 
         /* タグマップの作成 */
         for (final String line : lines) {
@@ -96,8 +106,8 @@ public class JavadocAppenderTool {
             }
 
             final String[] parts = KmgDelimiterTypes.SERIES_HALF_SPACE.split(trimmedLine, 2);
-            final String tag = parts[0].trim();
-            final String value = parts[1].trim();
+            final String   tag   = parts[0].trim();
+            final String   value = parts[1].trim();
             result.put(tag, value);
 
         }

--- a/src/main/resources/tool/io/template/JavadocAppenderTool.txt
+++ b/src/main/resources/tool/io/template/JavadocAppenderTool.txt
@@ -1,0 +1,3 @@
+@author KenichiroArai
+@sine 0.1.0
+@version 0.1.0


### PR DESCRIPTION
## 主な変更内容

### 基本構造の実装
- JavadocAppenderToolクラスの基本構造を実装
- テンプレートファイルのパスを追加
- 実行メソッドの実装

### 機能追加
- テンプレートからタグマップを設定する機能
- Javaファイルの内容を読み込む機能
- Javadocコメントを行ごとに抽出する機能
- タグに基づく行のスキップ機能
- tagMapの内容をJavadocに挿入する機能
- ファイルおよび行数のカウント機能

### 処理の改善
- テンプレートの読み込み処理の例外処理強化
- BufferedReaderを使用したファイル読み込み最適化
- Javadoc処理の最適化
- 開始行と終了行が同じ場合の処理追加
- タグを先頭に挿入するオプション追加

### エラーハンドリングとメッセージ表示
- ファイル書き込み処理のエラーハンドリング追加
- 処理開始・終了時のメッセージ表示
- 成功・失敗メッセージの表示機能

### コード品質の改善
- Javadocコメントの修正
- コードフォーマットの改善
- 静的メソッドの警告抑制
- 変数初期化の整理
- 戻り値の明示的な変数格納