### PR TITLE
#158 release.batのバージョン例を「v1.0.0」にした。

### DIFF
--- a/scripts/release.bat
+++ b/scripts/release.bat
@@ -48,7 +48,7 @@ powershell -command "$OutputEncoding = [System.Text.Encoding]::GetEncoding('shif
 REM パラメータのチェック
 IF "%~1"=="" (
     ECHO 使用方法：release.bat [作業ブランチ] [リリースブランチ] [バージョン]
-    ECHO 例：release.bat features/main main 1.0.0
+    ECHO 例：release.bat features/main main v1.0.0
     EXIT /b 1
 )
 


### PR DESCRIPTION
(kmg-tool-baseのv0.2.0としてリリースする #158)