### PR TITLE
#194 バージョンをv0.2.8にアップして、Eclipseの警告を修正した。

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>kmg.tool.base</groupId>
     <artifactId>kmg-tool-base</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8</version>
     <name>kmg-tool-base</name>
     <description>KMGツールベース</description>
     <packaging>jar</packaging>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>kmg.core</groupId>
             <artifactId>kmg-core</artifactId>
-            <version>0.2.6</version>
+            <version>0.2.7</version>
             <exclusions>
                 <!-- kmg-coreが含むJUnit依存関係を除外し、Spring Bootが管理するバージョンを使用 -->
                 <exclusion>
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>kmg.fund</groupId>
             <artifactId>kmg-fund</artifactId>
-            <version>0.2.4</version>
+            <version>0.2.6</version>
         </dependency>
 
         <!-- Spring -->

--- a/src/test/java/kmg/tool/base/dtc/domain/service/impl/DtcServiceImplTest.java
+++ b/src/test/java/kmg/tool/base/dtc/domain/service/impl/DtcServiceImplTest.java
@@ -35,7 +35,7 @@ import kmg.tool.base.dtc.domain.logic.DtcLogic;
  *
  * @since 0.2.0
  *
- * @version 0.2.4
+ * @version 0.2.8
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -632,6 +632,7 @@ public class DtcServiceImplTest extends AbstractKmgTest {
      * @throws KmgReflectionException
      *                                 リフレクション例外
      */
+    @SuppressWarnings("resource")
     @Test
     public void testProcess_normalWithIntermediateDelimiter() throws KmgToolBaseMsgException, KmgReflectionException {
 
@@ -677,6 +678,7 @@ public class DtcServiceImplTest extends AbstractKmgTest {
      * @throws KmgToolBaseMsgException
      *                                 KMGツールメッセージ例外
      */
+    @SuppressWarnings("resource")
     @Test
     public void testProcess_normalWithoutIntermediateDelimiter() throws KmgToolBaseMsgException {
 


### PR DESCRIPTION
(【kmg-tool-base】v0.2.8機能を実装してリリースする #194)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores（保守）**
  * プロジェクトバージョンを0.2.8にアップデート
  * 依存関係をアップデート

<!-- end of auto-generated comment: release notes by coderabbit.ai -->